### PR TITLE
Hide command if Git not available

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "commands": [
       {
         "command": "copy-branch-name.copy-current",
-        "title": "Copy current branch name"
+        "title": "Copy current branch name",
+        "icon": "$(copy)",
+        "enablement": "gitOpenRepositoryCount >= 1",
+        "shortTitle": "Copy current branch name"
       }
     ]
   },

--- a/src/commands/copy-branch.ts
+++ b/src/commands/copy-branch.ts
@@ -1,14 +1,10 @@
 import * as vscode from 'vscode';
-import { GitExtension } from '../@types/vscode.git';
+import { getGitRepository } from '../utils/git';
 import { showToastInStatusBar } from '../utils/statusbar';
 
 export const copyCurrentBranchNameCommand = async () => {
-  const gitExtension =
-    vscode.extensions.getExtension<GitExtension>('vscode.git')?.exports;
-  if (gitExtension) {
-    const api = gitExtension.getAPI(1);
-
-    const repo = api.repositories[0];
+  const repo = getGitRepository();
+  if (repo) {
     const branchName = (repo.state.HEAD && repo.state.HEAD.name) || '';
     try {
       await vscode.env.clipboard.writeText(branchName);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { copyCurrentBranchNameCommand } from './commands';
+import { getGitRepository } from './utils/git';
 import { showStatusBarButton } from './utils/statusbar';
 
 const commands: { id: string; callback: () => void }[] = [
@@ -7,7 +8,15 @@ const commands: { id: string; callback: () => void }[] = [
 ];
 
 export const activate = (context: vscode.ExtensionContext) => {
-  const extensionId = context.extension.id;
+  const extensionId = context.extension.packageJSON.name;
+  registerCommands(extensionId, context);
+
+  const isGitAvailable = !!getGitRepository();
+
+  if (!isGitAvailable) {
+    return;
+  }
+
   showStatusBarButton({
     alignment: vscode.StatusBarAlignment.Left,
     priority: 9999,
@@ -18,7 +27,12 @@ export const activate = (context: vscode.ExtensionContext) => {
     command: `${extensionId}.copy-current`,
     visible: true,
   });
+};
 
+const registerCommands = (
+  extensionId: any,
+  context: vscode.ExtensionContext
+) => {
   commands.forEach((command) => {
     const disposable = vscode.commands.registerCommand(
       `${extensionId}.${command.id}`,

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode';
+import { GitExtension } from '../@types/vscode.git';
+
+export const getGitRepository = () => {
+  const gitExtension =
+    vscode.extensions.getExtension<GitExtension>('vscode.git')?.exports;
+
+  return gitExtension?.getAPI(1).repositories?.[0];
+};


### PR DESCRIPTION
Hide the command as well as the status bar item if the current Git repository cannot be found. This can be the case when the user opens the VS Code instance in a directory without Git repository. Then it shouldn't be possible to run the command to copy the branch name.